### PR TITLE
pandoc 2.0 does not accept --smart, used --to html5+smart instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,10 @@ all: $(TARGETS)
 %.html: %.md tufte.html5 $(STYLES)
 	pandoc \
 		--katex \
-		--smart \
 		--section-divs \
 		--from markdown+tex_math_single_backslash \
 		--filter pandoc-sidenote \
-		--to html5 \
+		--to html5+smart \
 		--template=tufte \
 		$(foreach style,$(STYLES),--css $(notdir $(style))) \
 		--output $@ \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ STYLES := tufte-css/tufte.css \
 .PHONY: all
 all: $(TARGETS)
 
+# smart html 5 is different in pandoc 1 and pandoc 2
+PANDOCVERSIONGTEQ2 := $(shell expr `pandoc --version | grep ^pandoc | sed 's/^.* //g' | cut -f1 -d.` \>= 2)
+ifeq "$(PANDOCVERSIONGTEQ2)" "1"
+	SMART_HTML := --to html5+smart
+else
+	SMART_HTML := --smart --to html5
+endif
+
 ## Generalized rule: how to build a .html file from each .md
 %.html: %.md tufte.html5 $(STYLES)
 	pandoc \
@@ -18,7 +26,7 @@ all: $(TARGETS)
 		--section-divs \
 		--from markdown+tex_math_single_backslash \
 		--filter pandoc-sidenote \
-		--to html5+smart \
+		$(SMART_HTML) \
 		--template=tufte \
 		$(foreach style,$(STYLES),--css $(notdir $(style))) \
 		--output $@ \


### PR DESCRIPTION
pandoc 2.0 does not accept the --smart flag any more, the error message

```
$ make
pandoc \
		--katex \
		--smart \
		--section-divs \
		--from markdown+tex_math_single_backslash \
		--filter pandoc-sidenote \
		--to html5 \
		--template=tufte \
		--css tufte.css --css pandoc.css --css pandoc-solarized.css --css tufte-extra.css \
		--output docs/index.html \
		docs/index.md
--smart/-S has been removed.  Use +smart or -smart extension instead.
For example: pandoc -f markdown+smart -t markdown-smart.
Try pandoc --help for more information.
make: *** [docs/index.html] Error 2
```

suggests to use --to html5+smart instead.  I fixed this in the main Makefile.