### PR TITLE
Minor fixes

### DIFF
--- a/pandoc.css
+++ b/pandoc.css
@@ -74,3 +74,8 @@ pre:not(.sourceCode) code {
     width: 100%;
   }
 }
+
+/* Math formatting */
+.katex {
+  font-size: inherit !important;
+}

--- a/pandoc.css
+++ b/pandoc.css
@@ -79,3 +79,9 @@ pre:not(.sourceCode) code {
 .katex {
   font-size: inherit !important;
 }
+
+/* Wrap long URLs in references */
+#refs a {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
This addresses some issues I noticed with KaTeX math having an inconsistent font size and references being too wide on small screens.