### PR TITLE
Add CSL classes

### DIFF
--- a/tufte-extra.css
+++ b/tufte-extra.css
@@ -23,3 +23,38 @@ code {
 li:not(:first-child) {
     margin-top: initial;
 }
+
+/* To get the pandoc-generated bibliography to match style, define csl classes. */
+div.csl-bib-body {
+  font-size: 1.4rem;
+  width: 55%; 
+}
+div.csl-entry {
+  clear: both;
+  margin-top: .5em;
+}
+.hanging div.csl-entry {
+  margin-left:2em;
+  text-indent:-2em;
+}
+div.csl-left-margin {
+  min-width:2em;
+  float:left;
+}
+div.csl-right-inline {
+  margin-left:2em;
+  padding-left:1em;
+}
+div.csl-indent {
+  margin-left: 2em;
+}
+div.hanging-indent{
+  margin-left: 1.5em;
+  text-indent: -1.5em;
+}
+
+@media (max-width: 760px) {
+  div.csl-bib-body {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
_raised in https://github.com/jez/tufte-pandoc-css/issues/5#issue-929628831_

pandoc with the [`--citeproc` option](https://pandoc.org/MANUAL.html#option--citeproc) will generate citations and bibliography formatted according to a [CSL](https://docs.citationstyles.org/en/stable/specification.html) style. By default, it will use the chicago-author-date style. In HTML output, the bibliography is a div with `class="references csl-bib-body hanging-indent"`, and each entry in a div `class="csl-entry"`.  

This commit adds some CSS to make the bibliography behave more how it would be expected (normal sized text, and hanging-indented entries).