### PR TITLE
Styling for classic footnotes

### DIFF
--- a/tufte-extra.css
+++ b/tufte-extra.css
@@ -57,3 +57,30 @@ div.hanging-indent{
         width: 100%;
     }
 }
+
+/* Prevent superscripts and subscripts from affecting line-height */
+sup, sub {
+    vertical-align: baseline;
+    position: relative;
+    top: -0.4em;
+}
+sub { 
+    top: 0.4em; 
+}
+
+/* Replicate styling from sidenote numbers to footnote numbers */
+a.footnote-ref {
+    background: unset;
+    text-shadow: unset;
+    font-size: 1rem;
+    position: relative;
+    top: -0.1rem;
+    left: 0.1rem;
+    display: inline;
+}
+.footnote-ref sup {
+    font-family: et-book-roman-old-style;
+    font-size: inherit;
+    vertical-align: inherit;
+    line-height: inherit;
+}


### PR DESCRIPTION
I saw that in `pandoc-sidenote` you added a syntax for normal footnotes: https://github.com/jez/pandoc-sidenote/commit/73181b4e01e0707e6a4b3f4f37e11b1adc01e6a9

But the styling isn't great: the footnote numbers affect the line-height, they are underlined, and the styling isn't quite right. So this PR simply replicates the styling of sidenote numbers for footnote numbers.

---

In my own article I need to use both sidenotes and footnotes, so to differenciate them I replaced sidenote numbers with a * by adding this CSS:

```css
/* Optional : change sidenote numbers to a symbol */
.sidenote-number:after {
    content: '*';
    font-size: 1rem;
    top: -0.3rem;
    left: 0.1rem;
}
.sidenote:before {
    content: "*";
    font-size: 1rem;
    top: -0.3rem;
}
```

It gives me * sidenotes and numbered footnotes, like so:

<img width="1022" src="https://user-images.githubusercontent.com/31006039/174795337-0eeeb111-63bc-41b0-89d6-2d48c1e87f8c.png">

However I think it should remain optional so I didn't put it in the PR.